### PR TITLE
Fix parsing of leap year CSV urls

### DIFF
--- a/tap_adyen/cleaners.py
+++ b/tap_adyen/cleaners.py
@@ -114,7 +114,10 @@ def clean_dispute_transaction_details(
     )
 
     # Get file date
-    file_date: date = parse_date(csv_url.rstrip('.csv'), fuzzy=True).date()
+    file_date: date = parse_date(
+        csv_url.replace("_","-") # Can't parse leap years with underscores but can with dashes
+        ,fuzzy=True
+    ).date()
 
     # Create primary key
     date_string: str = '{date:%Y%m%d}'.format(date=file_date)  # noqa: WPS323
@@ -168,7 +171,10 @@ def clean_payment_accounting(
     mapping: Optional[dict] = STREAMS['payment_accounting'].get('mapping')
 
     # Get file date
-    file_date: date = parse_date(csv_url.rstrip('.csv'), fuzzy=True).date()
+    file_date: date = parse_date(
+        csv_url.replace("_","-"), # Can't parse date with underscores, but dashes work
+        fuzzy=True
+    ).date()
 
     # Create primary key
     date_string: str = '{date:%Y%m%d}'.format(date=file_date)  # noqa: WPS323

--- a/tap_adyen/cleaners.py
+++ b/tap_adyen/cleaners.py
@@ -115,7 +115,7 @@ def clean_dispute_transaction_details(
 
     # Get file date
     file_date: date = parse_date(
-        csv_url.replace("_","-") # Can't parse leap years with underscores but can with dashes
+        csv_url.replace("_","-") # Can't parse leap year days (Feb 29th) with underscores, but can with dashes
         ,fuzzy=True
     ).date()
 
@@ -172,7 +172,7 @@ def clean_payment_accounting(
 
     # Get file date
     file_date: date = parse_date(
-        csv_url.replace("_","-"), # Can't parse date with underscores, but dashes work
+        csv_url.replace("_","-"), # Can't parse leap year days (Feb 29th) with underscores, but can with dashes
         fuzzy=True
     ).date()
 

--- a/tap_adyen/tests/test_cleaners.py
+++ b/tap_adyen/tests/test_cleaners.py
@@ -14,8 +14,8 @@ class TestCleaners(unittest.TestCase):
         self.assertEqual(cleaned_row.get("existing_column"), 1)
         self.assertEqual(cleaned_row.get("missing_column"), None)
     
-    def test_cleaner_leap_year_date_parse(self):
-        dispute_row = { #Minimal test for dispute
+    def test_cleaners_leap_year_date_parse(self):
+        dispute_row = {
             'Record Date' : "2024-01-01",
             'Payment Date' : "2024-01-01",
             'Dispute Date' : "2024-01-01",
@@ -27,7 +27,7 @@ class TestCleaners(unittest.TestCase):
         row_number = 1
         dispute_csv_url = "https://dummy-url.adyen.com/reports/download/MerchantAccount/DummyMerchant/dispute_report_2024_02_29.csv"
         payment_csv_url = "https://dummy-url.adyen.com/reports/download/MerchantAccount/DummyMerchant/payments_account_report_2024_02_29.csv"
-        cleaned_dispute = clean_dispute_transaction_details(dispute_row,row_number,csv_url)
+        cleaned_dispute = clean_dispute_transaction_details(dispute_row,row_number,dispute_csv_url)
         cleaned_payment = clean_payment_accounting(payment_row,row_number,payment_csv_url)
         self.assertEqual(cleaned_dispute.get("id"),202402290000000001)
         self.assertEqual(cleaned_payment.get("id"),202402290000000001)

--- a/tap_adyen/tests/test_cleaners.py
+++ b/tap_adyen/tests/test_cleaners.py
@@ -25,13 +25,18 @@ class TestCleaners(unittest.TestCase):
             'Booking Date' : "2024-01-01"
         }
         row_number = 1
-        dispute_csv_url = "https://dummy-url.adyen.com/reports/download/MerchantAccount/DummyMerchant/dispute_report_2024_02_29.csv"
-        payment_csv_url = "https://dummy-url.adyen.com/reports/download/MerchantAccount/DummyMerchant/payments_account_report_2024_02_29.csv"
-        cleaned_dispute = clean_dispute_transaction_details(dispute_row,row_number,dispute_csv_url)
-        cleaned_payment = clean_payment_accounting(payment_row,row_number,payment_csv_url)
-        self.assertEqual(cleaned_dispute.get("id"),202402290000000001)
-        self.assertEqual(cleaned_payment.get("id"),202402290000000001)
-
-
+        leap_year_dispute_csv_url = "https://dummy-url.adyen.com/reports/download/MerchantAccount/DummyMerchant/dispute_report_2024_02_29.csv"
+        leap_year_payment_csv_url = "https://dummy-url.adyen.com/reports/download/MerchantAccount/DummyMerchant/payments_account_report_2024_02_29.csv"
+        normal_dispute_csv_url = "https://dummy-url.adyen.com/reports/download/MerchantAccount/DummyMerchant/dispute_report_2024_06_15.csv"
+        normal_payment_csv_url = "https://dummy-url.adyen.com/reports/download/MerchantAccount/DummyMerchant/payments_account_report_2024_06_15.csv"
+        cleaned_leap_year_dispute_row = clean_dispute_transaction_details(dispute_row,row_number,leap_year_dispute_csv_url)
+        cleaned_leap_year_payment_row = clean_payment_accounting(payment_row,row_number,leap_year_payment_csv_url)
+        cleaned_normal_year_dispute_row = clean_dispute_transaction_details(dispute_row,row_number,normal_dispute_csv_url)
+        cleaned_normal_year_payment_row = clean_payment_accounting(payment_row,row_number,normal_payment_csv_url)
+        self.assertEqual(cleaned_leap_year_dispute_row.get("id"),202402290000000001)      
+        self.assertEqual(cleaned_leap_year_payment_row.get("id"),202402290000000001)
+        self.assertEqual(cleaned_normal_year_dispute_row.get("id"),202406150000000001)
+        self.assertEqual(cleaned_normal_year_payment_row.get("id"),202406150000000001)
+        
 if __name__ == "__main__":
     unittest.main()

--- a/tap_adyen/tests/test_cleaners.py
+++ b/tap_adyen/tests/test_cleaners.py
@@ -1,19 +1,36 @@
 import unittest
-from tap_adyen.cleaners import clean_row
-
+from tap_adyen.cleaners import clean_row, clean_dispute_transaction_details,clean_payment_accounting
 
 class TestCleaners(unittest.TestCase):
     def test_clean_row_with_missing_columns(self):
         row = {"existing_column": "1"}
         mappers = {
-            "missing_column": {"type": int, "null": True},
-            "existing_column": {"type": int, "null": True},
+            "missing_column": {"type": int, "None": True},
+            "existing_column": {"type": int, "None": True},
         }
 
         cleaned_row = clean_row(row, mappers)
 
         self.assertEqual(cleaned_row.get("existing_column"), 1)
         self.assertEqual(cleaned_row.get("missing_column"), None)
+    
+    def test_cleaner_leap_year_date_parse(self):
+        dispute_row = { #Minimal test for dispute
+            'Record Date' : "2024-01-01",
+            'Payment Date' : "2024-01-01",
+            'Dispute Date' : "2024-01-01",
+            'Dispute End Date' : "2024-01-01",
+            }
+        payment_row = {
+            'Booking Date' : "2024-01-01"
+        }
+        row_number = 1
+        dispute_csv_url = "https://dummy-url.adyen.com/reports/download/MerchantAccount/DummyMerchant/dispute_report_2024_02_29.csv"
+        payment_csv_url = "https://dummy-url.adyen.com/reports/download/MerchantAccount/DummyMerchant/payments_account_report_2024_02_29.csv"
+        cleaned_dispute = clean_dispute_transaction_details(dispute_row,row_number,csv_url)
+        cleaned_payment = clean_payment_accounting(payment_row,row_number,payment_csv_url)
+        self.assertEqual(cleaned_dispute.get("id"),202402290000000001)
+        self.assertEqual(cleaned_payment.get("id"),202402290000000001)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
* Fixed bug from `dateutils.parser` not correctly fuzzy parsing dates with underscores in leap years e.g. `<full_url>/<report_name>_2024_02_29.csv`
* Added unittest for testing cleaner CSV filepath parsing for both leap-day and non-leap day.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209303772912942