### PR TITLE
Feature: Add simple retry logic to Adyen client

### DIFF
--- a/tap_adyen/adyen.py
+++ b/tap_adyen/adyen.py
@@ -9,6 +9,7 @@ from typing import Callable, Generator, Optional
 from time import sleep
 
 import requests
+import requests.adapters
 import singer
 
 API_SCHEME: str = "https://"
@@ -56,6 +57,10 @@ class Adyen(object):  # noqa: WPS230
 
         # Setup reusable web client
         self.client: requests.Session = requests.session()
+
+        # Enable simple retry logic as per https://docs.python-requests.org/en/latest/api/#requests.adapters.HTTPAdapter
+        self.client.mount("https://", requests.adapters.HTTPAdapter(max_retries=3))
+        self.client.mount("http://", requests.adapters.HTTPAdapter(max_retries=3))
 
         # Setup logger
         self.logger: logging.RootLogger = singer.get_logger()


### PR DESCRIPTION
* Added simple `max_retries=3` as per the [requests docs](https://docs.python-requests.org/en/latest/api/#requests.adapters.HTTPAdapter) to attempt to handle intermittent `ProtocolError('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))` exceptions